### PR TITLE
REFACT: main 페이지 리팩토링

### DIFF
--- a/acovue-client/src/components/Article/ArticleCard.css
+++ b/acovue-client/src/components/Article/ArticleCard.css
@@ -1,21 +1,24 @@
 .article-card {
   width: 100%;
+  min-width: 0;
   cursor: pointer;
 }
 
 .article-image {
   width: 100%;
-  height: 190px;
-  background-color: #e0e0e0;
-  object-fit: cover;
+  height: auto;
+  aspect-ratio: 1.35 / 1;
+  background-color: #fff;
+  object-fit: contain;
   display: block;
-  border-radius: 10px;
+  border-radius: 0;
 }
 
 .article-card h4 {
-  margin: 0.65rem 0 0;
-  font-size: 1rem;
-  line-height: 1.45;
+  margin: 0.45rem 0 0;
+  font-size: 0.78rem;
+  font-weight: 400;
+  line-height: 1.35;
   color: #222;
   display: -webkit-box;
   -webkit-line-clamp: 2;
@@ -24,11 +27,13 @@
 }
 
 @media (min-width: 768px) {
-  .article-image {
-    height: 250px;
-  }
-
   .article-card h4 {
-    font-size: 1.08rem;
+    font-size: 0.82rem;
+  }
+}
+
+@media (max-width: 520px) {
+  .article-card h4 {
+    font-size: 0.7rem;
   }
 }

--- a/acovue-client/src/components/Article/ArticleList.css
+++ b/acovue-client/src/components/Article/ArticleList.css
@@ -1,23 +1,32 @@
 .article-title {
-  border-left: 0.3rem solid #ffa600;
-  padding-left: 0.6rem;
-  margin-bottom: 0.3rem;
+  border-left: 4px solid #ff4b2f;
+  padding-left: 8px;
+  margin: 0 0 1rem;
+  color: #111;
+  font-size: 15px;
+  font-weight: 600;
+  line-height: 1.3;
 }
 
 .article-container {
-  min-height: 18rem;
+  min-height: 0;
 }
 
 .article-image-container {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
   margin: 1rem 0 0;
 }
 
 @media (min-width: 768px) {
-  .article-container {
-    min-height: 22rem;
-  }
-
   .article-image-container {
-    margin-top: 1.4rem;
+    margin-top: 1rem;
+  }
+}
+
+@media (max-width: 520px) {
+  .article-image-container {
+    gap: 0.75rem;
   }
 }

--- a/acovue-client/src/components/MiniList/MiniList.css
+++ b/acovue-client/src/components/MiniList/MiniList.css
@@ -1,7 +1,15 @@
+.list-container {
+  margin-top: 1.75rem;
+}
+
 .list-title {
-  border-left: 0.3rem solid #ffa600;
-  padding-left: 0.6rem;
-  margin-bottom: 0.3rem;
+  border-left: 4px solid #ff4b2f;
+  padding-left: 8px;
+  margin: 0 0 1rem;
+  color: #111;
+  font-size: 15px;
+  font-weight: 600;
+  line-height: 1.3;
 }
 
 .content-container {
@@ -11,9 +19,13 @@
 .content-box {
   display: flex;
   justify-content: space-between;
-  gap: 0.75rem;
-  margin-top: 0.85rem;
+  align-items: center;
+  gap: 1rem;
+  margin-top: 1.05rem;
   cursor: pointer;
+  color: #111;
+  font-size: 13px;
+  line-height: 1.35;
 }
 
 .content-box > div:first-child {
@@ -26,12 +38,24 @@
 
 .content-box > div:last-child {
   flex-shrink: 0;
-  color: #9ca3af;
-  font-size: 0.82rem;
+  color: #111;
+  font-size: 12px;
+  text-align: right;
 }
 
 @media (min-width: 768px) {
   .content-container {
-    margin: 1.3rem 0 3rem;
+    margin: 1.1rem 0 3rem;
+  }
+}
+
+@media (max-width: 520px) {
+  .content-box {
+    gap: 0.75rem;
+    font-size: 12px;
+  }
+
+  .content-box > div:last-child {
+    font-size: 11px;
   }
 }

--- a/acovue-client/src/index.css
+++ b/acovue-client/src/index.css
@@ -30,7 +30,7 @@
 * {
   box-sizing: border-box;
   /* !important를 붙여서 다른 라이브러리 스타일보다 우선순위를 높임 */
-  font-family: 'Spoqa Han Sans Neo', 'Spoqa Han Sans JP', sans-serif !important;
+  font-family: 'Freesentation', 'Spoqa Han Sans Neo', 'Spoqa Han Sans JP', sans-serif !important;
 }
 
 body {

--- a/acovue-client/src/pages/Community/Community.jsx
+++ b/acovue-client/src/pages/Community/Community.jsx
@@ -4,7 +4,7 @@ export default function Community() {
 
   const [community, setCommunity] = useState([]);
   useEffect(() => {
-    fetch("/api/post/find/all?type=COMMUNITY&limit=5")
+    fetch("/api/post/find/all?type=COMMUNITY&limit=8&page=1")
     .then ((res) => res.json())
     .then ((data) => setCommunity(data.data));
   },[])

--- a/acovue-client/src/pages/ConcertNews/ConcertNews.css
+++ b/acovue-client/src/pages/ConcertNews/ConcertNews.css
@@ -1,0 +1,92 @@
+.concert-news-section {
+  margin-top: 1.75rem;
+}
+
+.concert-news-list {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.concert-news-title,
+.home-section-title {
+  border-left: 4px solid #ff4b2f;
+  padding-left: 8px;
+  margin: 0 0 1rem;
+  color: #111;
+  font-size: 15px;
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+.concert-news-link {
+  color: inherit;
+  text-decoration: none;
+  display: block;
+  min-width: 0;
+}
+
+.concert-news-item {
+  min-width: 0;
+  cursor: pointer;
+}
+
+.concert-news-item .guide-list-item-image-container {
+  width: 100%;
+  min-width: 0;
+  height: auto;
+  min-height: 0;
+  aspect-ratio: 3 / 4;      
+  border-radius: 0;     
+  box-shadow: none;
+  background: #f2f2f2;
+}
+
+.concert-news-item .guide-list-item-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  background: #f2f2f2;
+}
+
+.concert-news-item .no-image-placeholder {
+  background: #e5e7eb;
+}
+
+.concert-news-item h3 {
+  margin: 0.55rem 0 0;
+  color: #222;
+  font-size: 0.9rem;
+  font-weight: 500;
+  line-height: 1.35;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  word-break: keep-all;
+}
+
+.concert-news-item p {
+  margin: 0.25rem 0 0;
+  color: #777;
+  font-size: 0.75rem;
+  line-height: 1.35;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+@media (max-width: 520px) {
+  .concert-news-list {
+    gap: 0.75rem;
+  }
+
+  .concert-news-item h3 {
+    font-size: 0.78rem;
+  }
+
+  .concert-news-item p {
+    font-size: 0.68rem;
+  }
+}

--- a/acovue-client/src/pages/ConcertNews/ConcertNews.jsx
+++ b/acovue-client/src/pages/ConcertNews/ConcertNews.jsx
@@ -1,0 +1,44 @@
+import { useEffect, useState } from "react";
+import {Link} from "react-router-dom"
+import "./ConcertNews.css";
+import { formatTime } from "../../components/Util/FormatTime";
+
+
+export default function ConcertNews() {
+
+    const [posts, setPosts] = useState([]);
+
+    useEffect(() => {
+        fetch("/api/post/find/all?type=CONCERT_NEWS&limit=3&page=1")
+        .then((res) => res.json())
+        .then((data) => setPosts(data.data));
+    }, []);
+
+
+
+    return(
+        <div className="concert-news-section">
+            <h2 className="concert-news-title">공연 소식</h2>
+            <div className="concert-news-list">
+                {posts.map((post) => (
+                    <Link key={post.postSeq} to={`/concert-news/${post.postSeq}`} className="concert-news-link">
+                        <div className="concert-news-item">
+                            <div className="guide-list-item-image-container">
+                                {post.thumbnailUrl? (
+                                    /*이미지 있을 때*/ 
+                                    <img className="guide-list-item-image" src={post.thumbnailUrl} alt={post.postTitle}/>
+                                ) : (
+                                    /* 이미지가 없을 때 */
+                                    <div className="no-image-placeholder">
+                                        <span> no image </span>
+                                    </div>
+                                )}
+                            </div>
+                            <h3>{post.postTitle}</h3>
+                        </div>
+                    </Link>
+                ))}
+            </div>
+        </div>
+    );
+}

--- a/acovue-client/src/pages/Guide/Guide.jsx
+++ b/acovue-client/src/pages/Guide/Guide.jsx
@@ -5,12 +5,12 @@ export default function Guide() {
   const [guide, setGuide] = useState([]);
 
   useEffect(() => {
-    fetch("/api/post/find/all?type=GUIDE&limit=1")
+    fetch("/api/post/find/all?type=GUIDE&limit=3&page=1")
       .then((res) => res.json())
       .then((data) => setGuide(data.data));
   }, []);
 
   return (
-    <ArticleList title="GUIDE" items={guide} />
+    <ArticleList title="원정 가이드" items={guide} />
   );
 }

--- a/acovue-client/src/pages/Home/Home.jsx
+++ b/acovue-client/src/pages/Home/Home.jsx
@@ -1,5 +1,6 @@
 import "./Home.css";
 import Guide from "../Guide/Guide.jsx";
+import ConcertNews from "../ConcertNews/ConcertNews.jsx";
 import Community from "../Community/Community.jsx";
 
 
@@ -9,7 +10,7 @@ export default function Home() {
     <div className="home-container">
         <div className="content-section">
           <Guide />
-          
+          <ConcertNews />
           <Community/>
         </div>
     </div>


### PR DESCRIPTION
• ## Summary

  - 메인 화면에 공연 소식 섹션을 추가했습니다.
  - 원정 가이드, 공연 소식, 커뮤니티 섹션의 헤더 스타일을 통일했습니다.
  - 메인 화면 카드/리스트 UI를 기획안 기준에 맞게 조정했습니다.
  - 전체 프로젝트 기본 폰트 우선순위에 `Freesentation`을 추가했습니다.

  ## Changes

  - 메인 화면에 `ConcertNews` 컴포넌트 추가
  - 공연 소식 최신 글 3개 조회 및 카드 형태 노출
  - 원정 가이드 최신 글 3개를 3열 카드 형태로 노출
  - 커뮤니티 리스트 날짜 색상 및 행 간격 조정
  - 가이드/공연 소식/커뮤니티 헤더를 동일한 좌측 포인트 바 스타일로 통일
  - 섹션 간 여백 조정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new Concert News section on the homepage displaying the latest concert posts with images and titles.
  * Added pagination support for community content.

* **Style**
  * Enhanced responsive design and typography across article components for better consistency across devices.
  * Improved layout spacing and visual hierarchy for titles and content areas.
  * Updated default font selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->