### PR TITLE
REFACT: 커뮤니티 리스트 페이지 수정

### DIFF
--- a/acovue-client/src/Approuter.jsx
+++ b/acovue-client/src/Approuter.jsx
@@ -9,6 +9,7 @@ import ConcertNewsPage from "./pages/ConcertNews/ConcertNewsListPage";
 import ConcertNewsDetailPage from "./pages/ConcertNews/ConcertNewsDetailPage";
 import ConcertNewsCreatePage from "./pages/ConcertNews/ConcertNewsCreatePage";
 import CommunityListPage from "./pages/Community/CommunityListPage";
+import CommunityCategoryListPage from "./pages/Community/CommunityCategoryListPage";
 import CommunityDetailPage from "./pages/Community/CommunityDetailPage";
 import CommunityCreatePage from "./pages/Community/CommunityCreatePage";
 import CommonUpdatePage from "./pages/Common/CommonUpdatePage";
@@ -32,6 +33,9 @@ export default function AppRouter() {
             <Route path="/concert-news/create" element={<ConcertNewsCreatePage/>}/>
             <Route path="/concert-news/:postId/update" element={<CommonUpdatePage category="CONCERT_NEWS" boardTitle="공연 소식 수정" prevPath="/concert-news?page=1&limit=5&type=CONCERT_NEWS"/>}/>
             <Route path="/community/" element={<CommunityListPage/>}/>
+            <Route path="/community/review" element={<CommunityCategoryListPage/>}/>
+            <Route path="/community/companion" element={<CommunityCategoryListPage/>}/>
+            <Route path="/community/qna" element={<CommunityCategoryListPage/>}/>
             <Route path="/community/:postId/" element={<CommunityDetailPage/>} />
             <Route path="/community/create" element={<CommunityCreatePage/>}/>
             <Route path="/community/:postId/update" element={<CommonUpdatePage category="COMMUNITY" boardTitle="커뮤니티 수정" prevPath="/community?page=1&limit=5&type=COMMUNITY"/>}/>

--- a/acovue-client/src/api/Post.api.js
+++ b/acovue-client/src/api/Post.api.js
@@ -1,8 +1,16 @@
 import client from "./Client";
 
 // 포스트 리스트 조회
-export const getPostList = (limit, page, type) =>
-  client.get(`/api/post/find/all?limit=${limit}&page=${page}&type=${type}`);
+export const getPostList = (limit, page, type, communityCategory) => {
+  const params = new URLSearchParams();
+
+  if (limit) params.set("limit", limit);
+  if (page) params.set("page", page);
+  if (type) params.set("type", type);
+  if (communityCategory) params.set("communityCategory", communityCategory);
+
+  return client.get(`/api/post/find/all?${params.toString()}`);
+};
 
 // 포스트 상세 조회
 export const getPostDetail = (postId) =>

--- a/acovue-client/src/pages/Community/CommunityCategoryListPage.jsx
+++ b/acovue-client/src/pages/Community/CommunityCategoryListPage.jsx
@@ -1,0 +1,126 @@
+import { Link, Navigate, NavLink, useLocation } from "react-router-dom";
+import { useEffect, useState } from "react";
+import { getPostList } from "../../api/Post.api";
+import LoadingSkeleton from "../../components/Common/LoadingSkeleton";
+import PageState from "../../components/Common/PageState";
+import { formatTime } from "../../components/Util/FormatTime";
+import {
+  COMMUNITY_CATEGORIES,
+  getCommunityCategoryByPath,
+} from "./communityCategories";
+import "./CommunityListPage.css";
+
+export default function CommunityCategoryListPage() {
+  const location = useLocation();
+  const categoryPath = location.pathname.split("/").filter(Boolean).at(-1);
+  const currentCategory = getCommunityCategoryByPath(categoryPath);
+  const [posts, setPosts] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+
+  const isNoticePost = (post) => post.notice === true || post.isNotice === true;
+
+  useEffect(() => {
+    if (!currentCategory) return;
+
+    setLoading(true);
+    setError(false);
+
+    getPostList(20, 1, "COMMUNITY", currentCategory.value)
+      .then((res) => {
+        const nextPosts = res.data.data || [];
+        setPosts(nextPosts);
+      })
+      .catch((error) => {
+        console.error("Failed to fetch community category:", error);
+        setError(true);
+      })
+      .finally(() => setLoading(false));
+  }, [currentCategory]);
+
+  if (!currentCategory) {
+    return <Navigate to="/community" replace />;
+  }
+
+  if (loading) return <LoadingSkeleton variant="list" />;
+
+  if (error) {
+    return (
+      <PageState
+        title="불러오기에 실패했습니다"
+        description="잠시 후 다시 시도해주세요."
+        actionLabel="다시 시도"
+        onAction={() => window.location.reload()}
+      />
+    );
+  }
+
+  return (
+    <main className="community-list-page">
+      <nav className="community-category-tabs" aria-label="커뮤니티 카테고리">
+        {COMMUNITY_CATEGORIES.map((category) => (
+          <NavLink
+            key={category.value}
+            to={`/community/${category.path}`}
+            className={({ isActive }) =>
+              `community-category-tab ${isActive ? "is-active" : ""}`
+            }
+          >
+            {category.label}
+          </NavLink>
+        ))}
+      </nav>
+
+      <section className="community-category-section">
+        <h1 className="community-preview-title">{currentCategory.label}</h1>
+
+        {!posts.length ? (
+          <PageState
+            title={`등록된 ${currentCategory.label} 글이 없습니다`}
+            description="첫 번째 글을 등록해보세요."
+          />
+        ) : (
+          <div className="community-category-posts">
+            {posts.filter(isNoticePost).map((post) => (
+              <Link
+                key={post.postSeq}
+                to={`/community/${post.postSeq}`}
+                className="community-category-notice"
+              >
+                <div className="community-category-post-title">
+                  <span className="community-notice-badge">공지</span>
+                  {post.postTitle}
+                </div>
+                <div className="community-category-post-meta">
+                  <span>{post.memberNickname}</span>
+                  <span>{formatTime(post.regDate)}</span>
+                </div>
+              </Link>
+            ))}
+
+            {posts.filter((post) => !isNoticePost(post)).map((post) => (
+              <Link
+                key={post.postSeq}
+                to={`/community/${post.postSeq}`}
+                className={`community-category-post ${post.thumbnailUrl ? "has-thumbnail" : ""}`}
+              >
+                {post.thumbnailUrl && (
+                  <div className="community-category-thumbnail">
+                    <img src={post.thumbnailUrl} alt={post.postTitle} />
+                  </div>
+                )}
+                <div className="community-category-post-body">
+                  <div className="community-category-post-title">{post.postTitle}</div>
+                  <div className="community-category-post-meta">
+                    <span>{post.memberNickname}</span>
+                    <span>{formatTime(post.regDate)}</span>
+                  </div>
+                </div>
+              </Link>
+            ))}
+          </div>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/acovue-client/src/pages/Community/CommunityListPage.css
+++ b/acovue-client/src/pages/Community/CommunityListPage.css
@@ -1,0 +1,255 @@
+.community-list-page {
+  width: min(100%, 768px);
+  margin: 0 auto 5rem;
+  padding: 0 1.75rem;
+  box-sizing: border-box;
+}
+
+.community-category-tabs {
+  display: flex;
+  align-items: center;
+  gap: 2rem;
+  min-height: 42px;
+  overflow-x: auto;
+  white-space: nowrap;
+  -webkit-overflow-scrolling: touch;
+}
+
+.community-category-tab {
+  color: #777;
+  text-decoration: none;
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1;
+}
+
+.community-category-tab.is-active {
+  color: #ff4b2f;
+  font-weight: 700;
+}
+
+.community-section-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.community-preview-section {
+  padding: 3.5rem 0 3rem;
+  border-bottom: 1px solid #d8d8d8;
+}
+
+.community-preview-section:last-child {
+  border-bottom: 0;
+}
+
+.community-category-section {
+  padding: 2.25rem 0 3rem;
+}
+
+.community-preview-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin: 0 0 1.25rem;
+}
+
+.community-preview-title {
+  border-left: 4px solid #ff4b2f;
+  padding-left: 8px;
+  margin: 0 0 20px 0;
+  color: #111;
+  font-size: 15px;
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+.community-preview-items {
+  display: flex;
+  flex-direction: column;
+  gap: 0.95rem;
+}
+
+.community-preview-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 100px 62px;
+  align-items: center;
+  gap: 1rem;
+  color: #111;
+  text-decoration: none;
+  font-size: 13px;
+  line-height: 1.35;
+}
+
+.community-preview-row:hover .community-preview-post-title {
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.community-preview-post-title {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.community-notice-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 18px;
+  padding: 0 6px;
+  margin-right: 0.45rem;
+  border-radius: 3px;
+  background: #ff4b2f;
+  color: #fff;
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 1;
+  vertical-align: 1px;
+}
+
+.community-section-more {
+  display: inline-flex;
+  color: #777;
+  text-decoration: none;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.community-section-more:hover {
+  color: #ff4b2f;
+}
+
+.community-category-posts {
+  display: flex;
+  flex-direction: column;
+}
+
+.community-category-notice {
+  display: block;
+  min-height: 64px;
+  padding: 0.55rem 0;
+  color: #111;
+  text-decoration: none;
+}
+
+.community-category-post {
+  display: block;
+  min-height: 64px;
+  padding: 0.55rem 0;
+  color: #111;
+  text-decoration: none;
+}
+
+.community-category-post.has-thumbnail {
+  display: grid;
+  grid-template-columns: 88px minmax(0, 1fr);
+  align-items: center;
+  gap: 1rem;
+  min-height: 82px;
+}
+
+.community-category-thumbnail {
+  width: 88px;
+  height: 64px;
+  border-radius: 6px;
+  overflow: hidden;
+  background: #cfcfcf;
+  flex-shrink: 0;
+}
+
+.community-category-thumbnail img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.community-category-post-body {
+  min-width: 0;
+}
+
+.community-category-post-title {
+  color: #111;
+  font-size: 15px;
+  font-weight: 700;
+  line-height: 1.35;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.community-category-post-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  margin-top: 0.35rem;
+  color: #999;
+  font-size: 11px;
+  line-height: 1.3;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.community-preview-date,
+.community-preview-author {
+  color: #111;
+  font-size: 12px;
+  text-align: right;
+  white-space: nowrap;
+}
+
+@media (min-width: 768px) {
+  .community-list-page {
+    padding: 0 2.5rem;
+  }
+}
+
+@media (max-width: 520px) {
+  .community-list-page {
+    padding: 0 1.25rem;
+  }
+
+  .community-category-tabs {
+    gap: 1.4rem;
+  }
+
+  .community-preview-section {
+    padding: 2.5rem 0 2.4rem;
+  }
+
+  .community-preview-row {
+    grid-template-columns: minmax(0, 1fr) 82px 48px;
+    gap: 0.65rem;
+    font-size: 12px;
+  }
+
+  .community-preview-date,
+  .community-preview-author {
+    font-size: 11px;
+  }
+
+  .community-category-post {
+    min-height: 60px;
+  }
+
+  .community-category-post.has-thumbnail {
+    grid-template-columns: 76px minmax(0, 1fr);
+    gap: 0.75rem;
+  }
+
+  .community-category-thumbnail {
+    width: 76px;
+    height: 58px;
+  }
+
+  .community-category-post-title {
+    font-size: 13px;
+  }
+
+  .community-category-post-meta {
+    font-size: 10px;
+    gap: 0.3rem;
+  }
+}

--- a/acovue-client/src/pages/Community/CommunityListPage.jsx
+++ b/acovue-client/src/pages/Community/CommunityListPage.jsx
@@ -1,56 +1,109 @@
-import { useSearchParams } from "react-router-dom";
-import { useEffect,useState } from "react";
-import GuideListView from "../../components/GuideList/GuideListView";
-import { getPostList } from "../../api/Post.api"
+import { Link } from "react-router-dom";
+import { useEffect, useState } from "react";
+import { getPostList } from "../../api/Post.api";
 import LoadingSkeleton from "../../components/Common/LoadingSkeleton";
 import PageState from "../../components/Common/PageState";
+import { formatTime } from "../../components/Util/FormatTime";
+import { COMMUNITY_CATEGORIES } from "./communityCategories";
+import "./CommunityListPage.css";
 
+export default function CommunityListPage() {
+  const [sectionPosts, setSectionPosts] = useState({});
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
 
-export default function CommunityListPage(){
-    const [searchParams] = useSearchParams();
-    const limit = searchParams.get('limit')
-    const page = searchParams.get('page')
-    const type = searchParams.get('type')
-
-    const [postList, setPostList] = useState(null);
-    const [loading, setLoading] = useState(true);
-    const [error, setError] = useState(false);
-
-    useEffect(() => {
+  useEffect(() => {
+    const fetchCommunitySections = async () => {
+      try {
         setLoading(true);
         setError(false);
-        getPostList(limit, page, type)
-            .then(res => setPostList(res.data.data || []))
-            .catch(() => setError(true))
-            .finally(() => setLoading(false));
-    }, [limit, page, type]);
 
-    if (loading) return <LoadingSkeleton variant="list" />;
-
-    if (error) {
-        return (
-            <PageState
-                title="불러오기에 실패했습니다"
-                description="잠시 후 다시 시도해주세요."
-                actionLabel="다시 시도"
-                onAction={() => window.location.reload()}
-            />
+        const responses = await Promise.all(
+          COMMUNITY_CATEGORIES.map((section) =>
+            getPostList(6, 1, "COMMUNITY", section.value)
+          )
         );
-    }
 
-    if (!postList?.length) {
-        return (
-            <PageState
-                title="등록된 COMMUNITY 글이 없습니다"
-                description="첫 번째 커뮤니티 글을 등록해보세요."
-            />
-        );
-    }
+        const nextSectionPosts = COMMUNITY_CATEGORIES.reduce((acc, section, index) => {
+          const posts = responses[index].data.data || [];
+          acc[section.value] = posts.filter((post) => !post.notice).slice(0, 5);
+          return acc;
+        }, {});
 
-    return(
-        <GuideListView
-            postList={postList}
-        />
-    )
+        setSectionPosts(nextSectionPosts);
+      } catch (error) {
+        console.error("Failed to fetch community sections:", error);
+        setError(true);
+      } finally {
+        setLoading(false);
+      }
+    };
 
+    fetchCommunitySections();
+  }, []);
+
+  const hasPosts = COMMUNITY_CATEGORIES.some(
+    (section) => sectionPosts[section.value]?.length
+  );
+
+  if (loading) return <LoadingSkeleton variant="list" />;
+
+  if (error) {
+    return (
+      <PageState
+        title="불러오기에 실패했습니다"
+        description="잠시 후 다시 시도해주세요."
+        actionLabel="다시 시도"
+        onAction={() => window.location.reload()}
+      />
+    );
+  }
+
+  if (!hasPosts) {
+    return (
+      <PageState
+        title="등록된 커뮤니티 글이 없습니다"
+        description="첫 번째 커뮤니티 글을 등록해보세요."
+      />
+    );
+  }
+
+  return (
+    <main className="community-list-page">
+      <div className="community-section-list">
+        {COMMUNITY_CATEGORIES.map((section) => (
+          <section
+            key={section.value}
+            id={`community-${section.value.toLowerCase()}`}
+            className="community-preview-section"
+          >
+            <div className="community-preview-header">
+              <h2 className="community-preview-title">{section.label}</h2>
+              <Link
+                to={`/community/${section.path}`}
+                className="community-section-more"
+              >
+                더보기
+              </Link>
+            </div>
+
+            <div className="community-preview-items">
+              {(sectionPosts[section.value] || []).map((post) => (
+                <Link
+                  key={post.postSeq}
+                  to={`/community/${post.postSeq}`}
+                  className="community-preview-row"
+                >
+                  <span className="community-preview-post-title">{post.postTitle}</span>
+                  <span className="community-preview-date">{formatTime(post.regDate)}</span>
+                  <span className="community-preview-author">{post.memberNickname}</span>
+                </Link>
+              ))}
+            </div>
+
+          </section>
+        ))}
+      </div>
+    </main>
+  );
 }

--- a/acovue-client/src/pages/Community/communityCategories.js
+++ b/acovue-client/src/pages/Community/communityCategories.js
@@ -1,0 +1,8 @@
+export const COMMUNITY_CATEGORIES = [
+  { label: "공연 후기", value: "REVIEW", path: "review" },
+  { label: "동행 양도", value: "COMPANION", path: "companion" },
+  { label: "Q&A", value: "QNA", path: "qna" },
+];
+
+export const getCommunityCategoryByPath = (path) =>
+  COMMUNITY_CATEGORIES.find((category) => category.path === path);


### PR DESCRIPTION
• ## ✅ 연관된 이슈
  > close #66 


  ## 📝 작업 내용
  - 커뮤니티 페이지 하위 카테고리 구조에 맞게 리팩토링함
    - 공연 후기
    - 동행 양도
    - Q&A
  - 커뮤니티 메인 페이지에서 카테고리별 게시글 미리보기 노출하도록 수정함
  - 각 카테고리 섹션에 `더보기` 버튼 추가함
  - `더보기` 클릭 시 해당 카테고리 리스트 페이지로 이동하도록 구현함
    - `/community/review`
    - `/community/companion`
    - `/community/qna`
  - 카테고리 리스트 페이지 상단에 하위 카테고리 네비게이션 추가함
  - 현재 선택된 카테고리는 주황색 active 스타일로 표시되도록 적용함
  - 공지 게시글은 리스트 상단에 별도로 노출되도록 수정함
  - 공지 게시글은 썸네일 없이 `공지` 배지, 제목, 작성자, 날짜만 표시되도록 변경함
  - 일반 게시글은 썸네일이 있는 경우에만 썸네일 노출되도록 수정함
  - 임시로 표시하던 댓글 수, 조회수, 좋아요 정보 제거함
  - 커뮤니티 목록 조회 API 호출 시 `communityCategory` 파라미터 전달 가능하도록 확장함

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added community category browsing for Review, Companion, and Q&A sections
  * Community landing page now displays posts organized by category with preview cards
  * Added "View More" links to explore full category pages
  * Post cards display author name, posting date, and notice badges where applicable

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WhooGeek/AcovueMagazine-Front/pull/67)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->