### PR TITLE
REFACT: community 페이지 count data 수신 및 반영

### DIFF
--- a/acovue-client/src/api/Comment.api.js
+++ b/acovue-client/src/api/Comment.api.js
@@ -4,6 +4,10 @@ import client from "./Client";
 export const getCommentDetail = (postId) =>
   client.get(`/api/post/comment/find/${postId}`);
 
+// 댓글 개수 조회
+export const getCommentCount = (postId) =>
+  client.get(`/api/post/comment/count/${postId}`);
+
 // 댓글 등록
 export const postComment = (postId, data) => {
   return client.post(`/api/post/comment/create/${postId}`, data)

--- a/acovue-client/src/components/PostDetail/PostDetailView.jsx
+++ b/acovue-client/src/components/PostDetail/PostDetailView.jsx
@@ -12,6 +12,7 @@ export default function PostDetailView({
   post,
   comments,
   postLikes,
+  commentCount,
   commentLikes,
   onCommentSubmit
 }) {
@@ -32,7 +33,7 @@ export default function PostDetailView({
       <PostDetailContent post={post} />
 
       {/* 액션 영역 */}
-      <PostDetailActions post={post} postLikes={postLikes} commentCount={comments.length} isLoggedIn={isLoggedIn} />
+      <PostDetailActions post={post} postLikes={postLikes} commentCount={commentCount ?? comments.length} isLoggedIn={isLoggedIn} />
 
       {/* 댓글 목록 */}
       <PostDetailComments comments={comments} commentLikes={commentLikes} post={post} currentUser={currentUser} onRefresh={onCommentSubmit}/>

--- a/acovue-client/src/pages/Community/CommunityCategoryListPage.jsx
+++ b/acovue-client/src/pages/Community/CommunityCategoryListPage.jsx
@@ -1,5 +1,6 @@
 import { Link, Navigate, NavLink, useLocation } from "react-router-dom";
 import { useEffect, useState } from "react";
+import { Heart, MessageCircle } from "lucide-react";
 import { getPostList } from "../../api/Post.api";
 import LoadingSkeleton from "../../components/Common/LoadingSkeleton";
 import PageState from "../../components/Common/PageState";
@@ -19,6 +20,22 @@ export default function CommunityCategoryListPage() {
   const [error, setError] = useState(false);
 
   const isNoticePost = (post) => post.notice === true || post.isNotice === true;
+  const getCommentCount = (post) => post.commentCount ?? post.comment_count ?? 0;
+  const getLikeCount = (post) => post.postLikeCount ?? post.likeCount ?? 0;
+  const renderCommentCount = (post) => (
+    <div className="community-category-comment-count" aria-label="댓글 수">
+      <span className="community-category-count">
+        <MessageCircle size={14} strokeWidth={1.8} aria-hidden="true" />
+        {getCommentCount(post)}
+      </span>
+    </div>
+  );
+  const renderLikeCount = (post) => (
+    <span className="community-category-like-count" aria-label="좋아요 수">
+      <Heart size={13} strokeWidth={1.8} aria-hidden="true" />
+      {getLikeCount(post)}
+    </span>
+  );
 
   useEffect(() => {
     if (!currentCategory) return;
@@ -84,16 +101,20 @@ export default function CommunityCategoryListPage() {
             {posts.filter(isNoticePost).map((post) => (
               <Link
                 key={post.postSeq}
-                to={`/community/${post.postSeq}`}
+                to={`/community/${post.postSeq}/`}
                 className="community-category-notice"
               >
-                <div className="community-category-post-title">
-                  <span className="community-notice-badge">공지</span>
-                  {post.postTitle}
+                <div className="community-category-post-header">
+                  <div className="community-category-post-title">
+                    <span className="community-notice-badge">공지</span>
+                    {post.postTitle}
+                  </div>
+                  {renderCommentCount(post)}
                 </div>
                 <div className="community-category-post-meta">
                   <span>{post.memberNickname}</span>
                   <span>{formatTime(post.regDate)}</span>
+                  {renderLikeCount(post)}
                 </div>
               </Link>
             ))}
@@ -101,7 +122,7 @@ export default function CommunityCategoryListPage() {
             {posts.filter((post) => !isNoticePost(post)).map((post) => (
               <Link
                 key={post.postSeq}
-                to={`/community/${post.postSeq}`}
+                to={`/community/${post.postSeq}/`}
                 className={`community-category-post ${post.thumbnailUrl ? "has-thumbnail" : ""}`}
               >
                 {post.thumbnailUrl && (
@@ -110,10 +131,14 @@ export default function CommunityCategoryListPage() {
                   </div>
                 )}
                 <div className="community-category-post-body">
-                  <div className="community-category-post-title">{post.postTitle}</div>
+                  <div className="community-category-post-header">
+                    <div className="community-category-post-title">{post.postTitle}</div>
+                    {renderCommentCount(post)}
+                  </div>
                   <div className="community-category-post-meta">
                     <span>{post.memberNickname}</span>
                     <span>{formatTime(post.regDate)}</span>
+                    {renderLikeCount(post)}
                   </div>
                 </div>
               </Link>

--- a/acovue-client/src/pages/Community/CommunityDetailPage.jsx
+++ b/acovue-client/src/pages/Community/CommunityDetailPage.jsx
@@ -2,7 +2,7 @@ import { useParams } from "react-router-dom";
 import { useEffect, useState } from "react";
 import PostDetailView from "../../components/PostDetail/PostDetailView"
 import { getPostDetail } from "../../api/Post.api";
-import { getCommentDetail } from "../../api/Comment.api";
+import { getCommentCount, getCommentDetail } from "../../api/Comment.api";
 import { getLikePost } from "../../api/Like.api";
 import LoadingSkeleton from "../../components/Common/LoadingSkeleton";
 import PageState from "../../components/Common/PageState";
@@ -11,9 +11,15 @@ export default function CommunityDetailPage() {
     const { postId } = useParams();
     const [post, setPost] = useState(null);
     const [comments, setComments] = useState([]);
+    const [commentCount, setCommentCount] = useState(0);
     const [postLikes, setPostLikes] = useState(0);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(false);
+    const countComments = (commentList) =>
+        commentList.reduce(
+            (total, comment) => total + 1 + (comment.children?.length || 0),
+            0
+        );
 
     useEffect(() => {
         setLoading(true);
@@ -21,16 +27,33 @@ export default function CommunityDetailPage() {
         Promise.all([
             getPostDetail(postId),
             getCommentDetail(postId),
+            getCommentCount(postId).catch(() => null),
             getLikePost(postId),
         ])
-            .then(([postRes, commentRes, likeRes]) => {
+            .then(([postRes, commentRes, commentCountRes, likeRes]) => {
+                const nextComments = commentRes.data.data || [];
                 setPost(postRes.data.data);
-                setComments(commentRes.data.data || []);
+                setComments(nextComments);
+                setCommentCount(commentCountRes?.data?.data?.commentCount ?? countComments(nextComments));
                 setPostLikes(likeRes.data.data.postLikeCount || 0);
             })
             .catch(() => setError(true))
             .finally(() => setLoading(false));
     }, [postId]);
+
+    const handleRefreshComments = async () => {
+        try {
+            const [commentRes, commentCountRes] = await Promise.all([
+                getCommentDetail(postId),
+                getCommentCount(postId).catch(() => null),
+            ]);
+            const nextComments = commentRes.data.data || [];
+            setComments(nextComments);
+            setCommentCount(commentCountRes?.data?.data?.commentCount ?? countComments(nextComments));
+        } catch (err) {
+            console.error("댓글 로딩 실패", err);
+        }
+    };
 
     if (loading) return <LoadingSkeleton variant="detail" />;
 
@@ -50,6 +73,8 @@ export default function CommunityDetailPage() {
             post={post}
             comments={comments}
             postLikes={postLikes}
+            commentCount={commentCount}
+            onCommentSubmit={handleRefreshComments}
         />
     );
 }

--- a/acovue-client/src/pages/Community/CommunityListPage.css
+++ b/acovue-client/src/pages/Community/CommunityListPage.css
@@ -72,7 +72,7 @@
 
 .community-preview-row {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 100px 62px;
+  grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
   gap: 1rem;
   color: #111;
@@ -135,8 +135,9 @@
 }
 
 .community-category-post {
-  display: block;
-  min-height: 64px;
+  display: flex;
+  align-items: center;
+  min-height: 82px;
   padding: 0.55rem 0;
   color: #111;
   text-decoration: none;
@@ -167,6 +168,15 @@
 }
 
 .community-category-post-body {
+  width: 100%;
+  min-width: 0;
+}
+
+.community-category-post-header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 0.75rem;
   min-width: 0;
 }
 
@@ -182,7 +192,7 @@
 
 .community-category-post-meta {
   display: flex;
-  align-items: center;
+  align-items: flex-start;
   gap: 0.45rem;
   margin-top: 0.35rem;
   color: #999;
@@ -192,12 +202,85 @@
   white-space: nowrap;
 }
 
-.community-preview-date,
-.community-preview-author {
+.community-category-comment-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  min-width: 32px;
+  color: #777;
+  white-space: nowrap;
+}
+
+.community-category-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.2rem;
+  min-width: 28px;
+  font-size: 11px;
+  line-height: 1;
+}
+
+.community-category-count svg {
+  flex: 0 0 auto;
+}
+
+.community-category-like-count {
+  display: inline-flex;
+  align-items: flex-start;
+  gap: 0.18rem;
+  min-width: 24px;
+  color: inherit;
+  font-size: 11px;
+  line-height: 1.3;
+}
+
+.community-category-like-count svg {
+  flex: 0 0 auto;
+  margin-top: 0.02rem;
+}
+
+.community-preview-meta {
+  display: inline-flex;
+  align-items: flex-start;
+  justify-content: flex-end;
+  gap: 0.45rem;
+  min-width: 96px;
   color: #111;
   font-size: 12px;
   text-align: right;
   white-space: nowrap;
+}
+
+.community-preview-like-count {
+  display: inline-flex;
+  align-items: flex-start;
+  gap: 0.18rem;
+  min-width: 24px;
+  color: inherit;
+  font-size: 12px;
+  line-height: 1.35;
+}
+
+.community-preview-like-count svg {
+  flex: 0 0 auto;
+  margin-top: 0.02rem;
+}
+
+.community-preview-comment-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.2rem;
+  min-width: 34px;
+  color: #777;
+  font-size: 11px;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.community-preview-comment-count svg {
+  flex: 0 0 auto;
 }
 
 @media (min-width: 768px) {
@@ -220,23 +303,35 @@
   }
 
   .community-preview-row {
-    grid-template-columns: minmax(0, 1fr) 82px 48px;
+    grid-template-columns: minmax(0, 1fr) auto;
     gap: 0.65rem;
     font-size: 12px;
   }
 
-  .community-preview-date,
-  .community-preview-author {
+  .community-preview-meta {
+    gap: 0.3rem;
+    min-width: 82px;
     font-size: 11px;
   }
 
+  .community-preview-like-count {
+    min-width: 22px;
+    font-size: 11px;
+  }
+
+  .community-preview-comment-count {
+    min-width: 30px;
+    font-size: 10px;
+  }
+
   .community-category-post {
-    min-height: 60px;
+    min-height: 72px;
   }
 
   .community-category-post.has-thumbnail {
     grid-template-columns: 76px minmax(0, 1fr);
     gap: 0.75rem;
+    min-height: 72px;
   }
 
   .community-category-thumbnail {
@@ -251,5 +346,23 @@
   .community-category-post-meta {
     font-size: 10px;
     gap: 0.3rem;
+  }
+
+  .community-category-post-header {
+    gap: 0.55rem;
+  }
+
+  .community-category-comment-count {
+    min-width: 28px;
+  }
+
+  .community-category-count {
+    min-width: 24px;
+    font-size: 10px;
+  }
+
+  .community-category-like-count {
+    min-width: 22px;
+    font-size: 10px;
   }
 }

--- a/acovue-client/src/pages/Community/CommunityListPage.jsx
+++ b/acovue-client/src/pages/Community/CommunityListPage.jsx
@@ -1,5 +1,6 @@
 import { Link } from "react-router-dom";
 import { useEffect, useState } from "react";
+import { Heart, MessageCircle } from "lucide-react";
 import { getPostList } from "../../api/Post.api";
 import LoadingSkeleton from "../../components/Common/LoadingSkeleton";
 import PageState from "../../components/Common/PageState";
@@ -45,6 +46,8 @@ export default function CommunityListPage() {
   const hasPosts = COMMUNITY_CATEGORIES.some(
     (section) => sectionPosts[section.value]?.length
   );
+  const getCommentCount = (post) => post.commentCount ?? post.comment_count ?? 0;
+  const getLikeCount = (post) => post.postLikeCount ?? post.likeCount ?? 0;
 
   if (loading) return <LoadingSkeleton variant="list" />;
 
@@ -95,8 +98,10 @@ export default function CommunityListPage() {
                   className="community-preview-row"
                 >
                   <span className="community-preview-post-title">{post.postTitle}</span>
-                  <span className="community-preview-date">{formatTime(post.regDate)}</span>
-                  <span className="community-preview-author">{post.memberNickname}</span>
+                  <span className="community-preview-meta">
+                    <span>{formatTime(post.regDate)}</span>
+                  </span>
+      
                 </Link>
               ))}
             </div>

--- a/acovue-client/src/pages/ConcertNews/ConcertNewsDetailPage.jsx
+++ b/acovue-client/src/pages/ConcertNews/ConcertNewsDetailPage.jsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react";
 
 import PostDetailView from "../../components/PostDetail/PostDetailView";
 import { getPostDetail } from "../../api/Post.api";
-import { getCommentDetail } from "../../api/Comment.api";
+import { getCommentCount, getCommentDetail } from "../../api/Comment.api";
 import { getLikePost } from "../../api/Like.api";
 import LoadingSkeleton from "../../components/Common/LoadingSkeleton";
 import PageState from "../../components/Common/PageState";
@@ -13,15 +13,26 @@ export default function ConcertNewsDetailPage() {
 
   const [post, setPost] = useState(null);
   const [comments, setComments] = useState([]);
+  const [commentCount, setCommentCount] = useState(0);
   const [postLikes, setPostLikes] = useState(0);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
+  const countComments = (commentList) =>
+    commentList.reduce(
+      (total, comment) => total + 1 + (comment.children?.length || 0),
+      0
+    );
 
   const fetchComments = async () => {
 
     try {
-      const res = await getCommentDetail(postId);
-      setComments(res.data.data); // 받아온 데이터로 state 업데이트
+      const [commentRes, commentCountRes] = await Promise.all([
+        getCommentDetail(postId),
+        getCommentCount(postId).catch(() => null),
+      ]);
+      const nextComments = commentRes.data.data || [];
+      setComments(nextComments);
+      setCommentCount(commentCountRes?.data?.data?.commentCount ?? countComments(nextComments));
     } catch (err) {
       console.error("댓글 로딩 실패", err);
     }
@@ -34,11 +45,14 @@ export default function ConcertNewsDetailPage() {
     Promise.all([
       getPostDetail(postId),
       getCommentDetail(postId),
+      getCommentCount(postId).catch(() => null),
       getLikePost(postId),
     ])
-      .then(([postRes, commentRes, likeRes]) => {
+      .then(([postRes, commentRes, commentCountRes, likeRes]) => {
+        const nextComments = commentRes.data.data || [];
         setPost(postRes.data.data);
-        setComments(commentRes.data.data || []);
+        setComments(nextComments);
+        setCommentCount(commentCountRes?.data?.data?.commentCount ?? countComments(nextComments));
         setPostLikes(likeRes.data.data.postLikeCount || 0);
       })
       .catch(() => setError(true))
@@ -68,6 +82,7 @@ export default function ConcertNewsDetailPage() {
       post={post}
       comments={comments}
       postLikes={postLikes}
+      commentCount={commentCount}
       onCommentSubmit={handleRefreshComments}
     />
   );

--- a/acovue-client/src/pages/Guide/GuideDetailPage.jsx
+++ b/acovue-client/src/pages/Guide/GuideDetailPage.jsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from "react";
 
 import PostDetailView from "../../components/PostDetail/PostDetailView";
 import { getPostDetail } from "../../api/Post.api";
-import { getCommentDetail } from "../../api/Comment.api";
+import { getCommentCount, getCommentDetail } from "../../api/Comment.api";
 import { getLikePost } from "../../api/Like.api";
 import LoadingSkeleton from "../../components/Common/LoadingSkeleton";
 import PageState from "../../components/Common/PageState";
@@ -13,15 +13,26 @@ export default function GuideDetailPage() {
 
   const [post, setPost] = useState(null);
   const [comments, setComments] = useState([]);
+  const [commentCount, setCommentCount] = useState(0);
   const [postLikes, setPostLikes] = useState(0);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
+  const countComments = (commentList) =>
+    commentList.reduce(
+      (total, comment) => total + 1 + (comment.children?.length || 0),
+      0
+    );
 
   const fetchComments = async () => {
 
     try {
-      const res = await getCommentDetail(postId);
-      setComments(res.data.data); // 받아온 데이터로 state 업데이트
+      const [commentRes, commentCountRes] = await Promise.all([
+        getCommentDetail(postId),
+        getCommentCount(postId).catch(() => null),
+      ]);
+      const nextComments = commentRes.data.data || [];
+      setComments(nextComments);
+      setCommentCount(commentCountRes?.data?.data?.commentCount ?? countComments(nextComments));
     } catch (err) {
       console.error("댓글 로딩 실패", err);
     }
@@ -34,11 +45,14 @@ export default function GuideDetailPage() {
     Promise.all([
       getPostDetail(postId),
       getCommentDetail(postId),
+      getCommentCount(postId).catch(() => null),
       getLikePost(postId),
     ])
-      .then(([postRes, commentRes, likeRes]) => {
+      .then(([postRes, commentRes, commentCountRes, likeRes]) => {
+        const nextComments = commentRes.data.data || [];
         setPost(postRes.data.data);
-        setComments(commentRes.data.data || []);
+        setComments(nextComments);
+        setCommentCount(commentCountRes?.data?.data?.commentCount ?? countComments(nextComments));
         setPostLikes(likeRes.data.data.postLikeCount || 0);
       })
       .catch(() => setError(true))
@@ -68,6 +82,7 @@ export default function GuideDetailPage() {
       post={post}
       comments={comments}
       postLikes={postLikes}
+      commentCount={commentCount}
       onCommentSubmit={handleRefreshComments}
     />
   );


### PR DESCRIPTION
 ## ✅ 연관된 이슈

  > close #123

  ## 📝 작업 내용

  > 커뮤니티 리스트/상세 화면에서 백엔드가 내려주는 댓글 수와 좋아요 수를 표시하도록 프론트 UI와 데이
  > 터 연결을 수정

  - 커뮤니티 메인 리스트에서 게시글별 댓글 수/좋아요 수 표시
  - 커뮤니티 하위 카테고리 리스트(공연 후기, 동행 양도, Q&A)에서 게시글별 댓글 수/좋아요 수 표시
  - 좋아요 수는 작성자/날짜 메타 영역과 같은 톤으로 정렬
  - 댓글 수는 리스트 우측 영역에 배치
  - 게시글 상세 페이지에서 getCommentCount(postId)를 사용해 댓글 개수 표시
  - 댓글 개수 API 실패 시 댓글 목록 기반으로 개수를 계산하는 fallback 처리
  - 커뮤니티 리스트 row 간격 및 우측 정렬 CSS 조정
  - 썸네일 유무와 관계없이 하위 카테고리 일반 게시글 row 높이/간격이 일정하도록 CSS 보정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Comment and like counts now displayed on community posts, category lists, and detail pages
  * Added icons to visually identify comment and like metrics

* **Style**
  * Refined layout and styling for improved display of post engagement metrics across all pages

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WhooGeek/AcovueMagazine-Front/pull/69?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->