### PR TITLE
FIX: retry requests after token reissue

### DIFF
--- a/acovue-client/src/api/Client.js
+++ b/acovue-client/src/api/Client.js
@@ -4,6 +4,10 @@ const client = axios.create({
     withCredentials: true,
 });
 
+const refreshClient = axios.create({
+    withCredentials: true,
+});
+
 // 인터셉터 요청
 client.interceptors.request.use(
     (config) =>{
@@ -17,6 +21,60 @@ client.interceptors.request.use(
         return config;
     },
     (error) => {
+        return Promise.reject(error);
+    }
+);
+
+client.interceptors.response.use(
+    (response) => response,
+    async (error) => {
+        const originalRequest = error.config;
+
+        if(!originalRequest){
+            return Promise.reject(error);
+        }
+
+        if(error.response?.status === 401 && !originalRequest._retry){
+
+            originalRequest._retry = true;
+
+            try{
+                const refreshToken = localStorage.getItem("refreshToken");
+
+                if(!refreshToken){
+                    localStorage.removeItem("accessToken");
+                    localStorage.removeItem("refreshToken");
+                    window.location.href = "/login";
+                    return Promise.reject(error);
+                }
+                
+                const response = await refreshClient.post("/api/member/reissue", null,{
+                    headers: {
+                        "Refresh-Token": `Bearer ${refreshToken}`,
+                    },
+                });
+
+                const newAccessToken = response.data?.data?.accessToken;
+
+                if(!newAccessToken){
+                    throw new Error("새 accessToken이 응답에 없습니다.");
+                }
+
+                localStorage.setItem("accessToken", newAccessToken);
+
+                originalRequest.headers = originalRequest.headers || {};
+                originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
+
+                return client(originalRequest);
+                } catch(refreshError){
+                    console.error("토큰 재발급 실패", refreshError);
+                    localStorage.removeItem("accessToken");
+                    localStorage.removeItem("refreshToken");
+                    window.location.href = "/login";
+                    return Promise.reject(refreshError);
+                }
+            }
+
         return Promise.reject(error);
     }
 );

--- a/acovue-client/src/pages/Login/AdminLoginPage.jsx
+++ b/acovue-client/src/pages/Login/AdminLoginPage.jsx
@@ -14,8 +14,10 @@ export default function AdminLoginPage() {
       const response = await postLogin(email, password);
 
       if (response.data && response.data.accessToken) {
-        const token = response.data.accessToken;
-        localStorage.setItem("accessToken", token);
+        const accesstoken = response.data.accessToken;
+        const refreshToken = response.data.refreshToken;
+        localStorage.setItem("accessToken", accesstoken);
+        localStorage.setItem("refreshToken", refreshToken);
         window.location.href = "/";
       }
     } catch (error) {


### PR DESCRIPTION
 ## ✅ 연관된 이슈

  > close #79

  ## 📝 작업 내용

  > AccessToken 만료 시 RefreshToken으로 새 AccessToken을 재발급받고, 실패했던 요청을 자동으로 재시도하도록 프론트 인증 흐름을 개선

  - Axios response interceptor 추가
      - API 응답이 401인 경우 토큰 재발급 시도
      - _retry 플래그로 무한 재시도 방지
  - RefreshToken 기반 AccessToken 재발급 연동
      - POST /api/member/reissue 호출
      - Refresh-Token 헤더에 RefreshToken 전달
      - 응답으로 받은 새 AccessToken을 localStorage에 저장
  - 기존 실패 요청 자동 재시도 처리
      - 새 AccessToken을 Authorization 헤더에 반영
      - 기존 요청을 다시 호출하여 로그인 유지 UX 개선
  - RefreshToken이 없거나 재발급 실패 시 인증 정보 정리
      - accessToken, refreshToken 제거
      - 로그인 페이지로 이동
  - 관리자 로그인 시 RefreshToken도 저장하도록 수정
      - AccessToken 만료 후 자동 재발급 흐름이 동작하도록 처리

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic token refresh: The app now automatically attempts to refresh authentication tokens when they expire, allowing sessions to continue uninterrupted without requiring manual re-authentication.

* **Bug Fixes**
  * Enhanced authentication flow: Token storage now properly manages both access and refresh tokens to support the automatic refresh mechanism.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/WhooGeek/AcovueMagazine-Front/pull/80?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->